### PR TITLE
Add `container` variable to config

### DIFF
--- a/Source/Classes/CloudCore.swift
+++ b/Source/Classes/CloudCore.swift
@@ -91,7 +91,7 @@ open class CloudCore {
 		#endif
 		
 		// Fetch updated data (e.g. push notifications weren't received)
-		let updateFromCloudOperation = FetchAndSaveOperation(persistentContainer: container)
+        let updateFromCloudOperation = FetchAndSaveOperation(from: allDatabases, persistentContainer: container)
 		updateFromCloudOperation.errorBlock = {
 			self.delegate?.error(error: $0, module: .some(.fetchFromCloud))
 		}
@@ -153,7 +153,7 @@ open class CloudCore {
 		- completion: `FetchResult` enumeration with results of operation
 	*/
 	public static func fetchAndSave(to container: NSPersistentContainer, error: ErrorBlock?, completion: (() -> Void)?) {
-		let operation = FetchAndSaveOperation(persistentContainer: container)
+        let operation = FetchAndSaveOperation(from: allDatabases, persistentContainer: container)
 		operation.errorBlock = error
 		operation.completionBlock = completion
 
@@ -169,6 +169,16 @@ open class CloudCore {
 		return (database(for: userInfo) != nil)
 	}
 	
+    /// Private cloud database for the CKContainer specified by CloudCoreConfig
+    static var allDatabases: [CKDatabase] {
+        let container = config.container
+        return [
+            //container.publicCloudDatabase,
+            container.privateCloudDatabase,
+            //container.sharedCloudDatabase
+        ]
+    }
+    
 	static func database(for notificationUserInfo: NotificationUserInfo) -> CKDatabase? {
 		guard let notificationDictionary = notificationUserInfo as? [String: NSObject] else { return nil }
 		let notification = CKNotification(fromRemoteNotificationDictionary: notificationDictionary)
@@ -176,9 +186,9 @@ open class CloudCore {
 		guard let id = notification.subscriptionID else { return nil }
 		
 		switch id {
-		case config.subscriptionIDForPrivateDB: return CKContainer.default().privateCloudDatabase
-		case config.subscriptionIDForSharedDB: return CKContainer.default().sharedCloudDatabase
-		case _ where id.hasPrefix(config.publicSubscriptionIDPrefix): return CKContainer.default().publicCloudDatabase
+		case config.subscriptionIDForPrivateDB: return config.container.privateCloudDatabase
+		case config.subscriptionIDForSharedDB: return config.container.sharedCloudDatabase
+		case _ where id.hasPrefix(config.publicSubscriptionIDPrefix): return config.container.publicCloudDatabase
 		default: return nil
 		}
 	}

--- a/Source/Classes/Fetch/FetchAndSaveOperation.swift
+++ b/Source/Classes/Fetch/FetchAndSaveOperation.swift
@@ -12,13 +12,6 @@ import CoreData
 /// An operation that fetches data from CloudKit and saves it to Core Data, you can use it without calling `CloudCore.fetchAndSave` methods if you application relies on `Operation`
 public class FetchAndSaveOperation: Operation {
 	
-	/// Private cloud database
-	public static let allDatabases = [
-		//		CKContainer.default().publicCloudDatabase,
-		CKContainer.default().privateCloudDatabase,
-//		CKContainer.default().sharedCloudDatabase
-	]
-	
 	public typealias NotificationUserInfo = [AnyHashable : Any]
 	
 	private let tokens: Tokens
@@ -36,7 +29,7 @@ public class FetchAndSaveOperation: Operation {
 	///   - databases: list of databases to fetch data from (only private is supported now)
 	///   - persistentContainer: `NSPersistentContainer` that will be used to save data
 	///   - tokens: previously saved `Tokens`, you can generate new ones if you want to fetch all data
-	public init(from databases: [CKDatabase] = FetchAndSaveOperation.allDatabases, persistentContainer: NSPersistentContainer, tokens: Tokens = CloudCore.tokens) {
+	public init(from databases: [CKDatabase], persistentContainer: NSPersistentContainer, tokens: Tokens = CloudCore.tokens) {
 		self.tokens = tokens
 		self.databases = databases
 		self.persistentContainer = persistentContainer

--- a/Source/Classes/Save/ObjectToRecord/ObjectToRecordConverter.swift
+++ b/Source/Classes/Save/ObjectToRecord/ObjectToRecordConverter.swift
@@ -120,7 +120,7 @@ class ObjectToRecordConverter {
 	
 	/// Get appropriate database for modify operations
 	private func database(for recordID: CKRecordID, serviceAttributes: ServiceAttributeNames) -> CKDatabase {
-		let container = CKContainer.default()
+		let container = CloudCore.config.container
 		
 		if serviceAttributes.isPublic { return container.publicCloudDatabase }
 		

--- a/Source/Classes/Setup Operation/CreateCloudCoreZoneOperation.swift
+++ b/Source/Classes/Setup Operation/CreateCloudCoreZoneOperation.swift
@@ -27,7 +27,7 @@ class CreateCloudCoreZoneOperation: AsynchronousOperation {
 			self.state = .finished
 		}
 		
-		CKContainer.default().privateCloudDatabase.add(recordZoneOperation)
+		CloudCore.config.container.privateCloudDatabase.add(recordZoneOperation)
 		self.createZoneOperation = recordZoneOperation
 	}
 	

--- a/Source/Classes/Setup Operation/SubscribeOperation.swift
+++ b/Source/Classes/Setup Operation/SubscribeOperation.swift
@@ -20,7 +20,7 @@ class SubscribeOperation: AsynchronousOperation {
 	override func main() {
 		super.main()
 
-		let container = CKContainer.default()
+		let container = CloudCore.config.container
 		
 		// Subscribe operation
 		let subcribeToPrivate = self.makeRecordZoneSubscriptionOperation(for: container.privateCloudDatabase, id: CloudCore.config.subscriptionIDForPrivateDB)

--- a/Source/Model/CloudCoreConfig.swift
+++ b/Source/Model/CloudCoreConfig.swift
@@ -27,6 +27,12 @@ public struct CloudCoreConfig {
 	
 	// MARK: CloudKit
 	
+    /// The CKContainer to store CoreData. Set this to a custom container to
+    /// support sharing data between multiple apps in an App Group (e.g. iOS and macOS).
+    ///
+    /// Default value is `CKContainer.default()`
+    public var container = CKContainer.default()
+    
 	/// RecordZone inside private database to store CoreData.
 	///
 	/// Default value is `CloudCore`


### PR DESCRIPTION
Thanks for the great library, Vasily! If you're open to it, I would like to contribute some code to CloudCore as I add features and fix bugs to support my app.

About this PR: 
I need to use a custom `CKContainer` in my app so that Core Data can sync between an iOS app and a Mac app. I made the following changes to support using a custom `CKContainer`:

- Added a `container: CKContainer` variable to `CloudCoreConfig`
- Replaced references to `CKContainer.default()` with `CloudCore.config.container`
- Moved `allDatabases` from `FetchAndSaveOperation` to `CloudCore`
- Removed the default parameter value from `FetchAndSaveOperation.init` and passed in `allDatabases` for the appropriate inits (`CloudCore`, lines 94 and 156)

If you have any questions about this or if you would like me to change anything, just let me know. :)