### PR TITLE
Adding relationship order in CKFetchRecordZoneChangesOperation

### DIFF
--- a/CloudCore.xcodeproj/project.pbxproj
+++ b/CloudCore.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8D8B20EB2062E2B700F27057 /* Graph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8B20EA2062E2B700F27057 /* Graph.swift */; };
 		D9089D4A1FE14E57000FC60C /* SetupOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9089D491FE14E57000FC60C /* SetupOperation.swift */; };
 		D97465F81FE319930060EA66 /* CloudCoreDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97465F71FE319930060EA66 /* CloudCoreDelegate.swift */; };
 		D97465FA1FE31A650060EA66 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97465F91FE31A650060EA66 /* Module.swift */; };
@@ -89,6 +90,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8D8B20EA2062E2B700F27057 /* Graph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Graph.swift; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* CloudCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CloudCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5C6298B1C3A8BBD007F7B7C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9089D491FE14E57000FC60C /* SetupOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupOperation.swift; sourceTree = "<group>"; };
@@ -483,6 +485,7 @@
 				E22A53D91E4A8743009286C0 /* CloudKitAttribute.swift */,
 				E2EE20061E4E6DCE0060F769 /* ServiceAttributeName.swift */,
 				E2E296C91E49DA0800E7D6ED /* Tokens.swift */,
+				8D8B20EA2062E2B700F27057 /* Graph.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -715,6 +718,7 @@
 				E2C02A0E1E4C99AD001B2871 /* ObjectToRecordConverter.swift in Sources */,
 				D985DE9D1FDFF9D400236870 /* PurgeLocalDatabaseOperation.swift in Sources */,
 				E2FA74481E769D9400C3489D /* RecordIDWithDatabase.swift in Sources */,
+				8D8B20EB2062E2B700F27057 /* Graph.swift in Sources */,
 				E29BB2211E4344E80020F5B6 /* CKRecord.swift in Sources */,
 				E2D390081E4A49350019BBCD /* NSEntityDescription.swift in Sources */,
 				E29BB2231E4346FF0020F5B6 /* NSManagedObject.swift in Sources */,

--- a/Source/Model/Graph.swift
+++ b/Source/Model/Graph.swift
@@ -1,0 +1,100 @@
+//
+//  Graph.swift
+//  CloudCore
+//
+//  Created by Juan Ignacio on 3/21/18.
+//  Copyright © 2018 Vasily Ulianov. All rights reserved.
+//
+
+// Part of this code are from the SwiftGraph project: https://github.com/davecom/SwiftGraph
+class Graph {
+    
+    var vertices : [String]
+    var edges = [String:[String]]()
+    
+    init(vertices:[String]) {
+        self.vertices = vertices
+        vertices.forEach {
+            self.edges[$0] = [String]()
+        }
+    }
+    
+    func addEdge(from:String, to:String) {
+        edges[from]!.append(to)
+    }
+    
+    func indexOfVertex(_ v:String) -> Int? {
+        return vertices.index(of: v)
+    }
+    
+    func neighborsForVertex(_ v:String) -> [String]? {
+        return edges[v]
+    }
+    
+    func detectCycles() -> [[String]] {
+        var cycles = [[String]]() // store of all found cycles
+        var openPaths: [[String]] = vertices.map{ [$0] } // initial open paths are single vertex lists
+        
+        while openPaths.count > 0 {
+            let openPath = openPaths.removeFirst() // queue pop()
+            //if openPath.count > maxK { return cycles } // do we want to stop at a certain length k
+            if let tail = openPath.last, let head = openPath.first {
+                let neighbors = neighborsForVertex(tail)!
+                for neighbor in neighbors {
+                    
+                    if neighbor == head {
+                        cycles.append(openPath + [neighbor]) // found a cycle
+                    } else if !openPath.contains(neighbor) && indexOfVertex(neighbor)! > indexOfVertex(head)! {
+                        openPaths.append(openPath + [neighbor]) // another open path to explore
+                    }
+                }
+            }
+        }
+        return cycles
+    }
+    
+    
+    func topologicalSort() -> [String]? {
+        var sortedVertices = [String]()
+        let tsNodes = vertices.map{ TSNode<String>(vertex: $0, color: .white) }
+        var notDAG = false
+        
+        func visit(_ node: TSNode<String>) {
+            guard node.color != .gray else {
+                notDAG = true
+                return
+            }
+            if node.color == .white {
+                node.color = .gray
+                for inode in tsNodes where (neighborsForVertex(node.vertex)?.contains(inode.vertex))! {
+                    visit(inode)
+                }
+                node.color = .black
+                sortedVertices.insert(node.vertex, at: 0)
+            }
+        }
+        
+        for node in tsNodes where node.color == .white {
+            visit(node)
+        }
+        
+        if notDAG {
+            return nil
+        }
+        
+        return sortedVertices
+    }
+    
+    fileprivate enum TSColor { case black, gray, white }
+    
+    fileprivate class TSNode<String> {
+        fileprivate let vertex: String
+        fileprivate var color: TSColor
+        
+        init(vertex: String, color: TSColor) {
+            self.vertex = vertex
+            self.color = color
+        }
+    }
+}
+


### PR DESCRIPTION
It stores the records until fetch is completed, and then tries to process them in relationship order when the topological sort in the entity graph is possible. If it's not possible then it performs the update operations many times so all the relationships are fullfilled.

Fix #27