### PR TITLE
Enabling subentities

### DIFF
--- a/Source/Classes/Fetch/SubOperations/PurgeLocalDatabaseOperation.swift
+++ b/Source/Classes/Fetch/SubOperations/PurgeLocalDatabaseOperation.swift
@@ -32,7 +32,6 @@ class PurgeLocalDatabaseOperation: Operation {
 			
 			let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
 			fetchRequest.includesPropertyValues = false
-			fetchRequest.includesSubentities = false
 			
 			do {
 				// I don't user `NSBatchDeleteRequest` because we can't notify viewContextes about changes

--- a/Source/Model/CloudKitAttribute.swift
+++ b/Source/Model/CloudKitAttribute.swift
@@ -54,7 +54,6 @@ class CloudKitAttribute {
 		fetchRequest.predicate = NSPredicate(format: serviceAttributes.recordID + " == %@" , recordID.encodedString)
 		fetchRequest.fetchLimit = 1
 		fetchRequest.includesPropertyValues = false
-		fetchRequest.includesSubentities = false
 		
 		let foundObject = try context.fetch(fetchRequest).first as? NSManagedObject
 		


### PR DESCRIPTION
Removing two lines of `fetchRequest.includesSubentities = false`, includesSubentities defaults to yes.